### PR TITLE
fix: reexport enum `DuckDBAccessMode`

### DIFF
--- a/packages/duckdb-wasm/src/storage.ts
+++ b/packages/duckdb-wasm/src/storage.ts
@@ -1,6 +1,6 @@
-import type { DuckDBAccessMode } from '@duckdb/duckdb-wasm'
+import { DuckDBAccessMode } from '@duckdb/duckdb-wasm'
 
-export type { DuckDBAccessMode }
+export { DuckDBAccessMode }
 
 export enum DBStorageType {
   ORIGIN_PRIVATE_FS = 'origin-private-fs',


### PR DESCRIPTION
If only export type, other packages which dependent this will cannot access values of `DuckDBAccessMode`